### PR TITLE
Add Adaptive banner support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,5 +41,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    api 'com.google.firebase:firebase-ads:18.3.0'
+    api 'com.google.firebase:firebase-ads:19.0.1'
 }

--- a/android/src/main/kotlin/com/shatsy/admobflutter/AdmobBanner.kt
+++ b/android/src/main/kotlin/com/shatsy/admobflutter/AdmobBanner.kt
@@ -2,7 +2,6 @@ package com.shatsy.admobflutter
 
 import android.content.Context
 import android.view.View
-import com.google.android.gms.ads.AdListener
 import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.AdSize
 import com.google.android.gms.ads.AdView
@@ -20,14 +19,14 @@ class AdmobBanner(context: Context, messenger: BinaryMessenger, id: Int, args: H
   init {
     channel.setMethodCallHandler(this)
 
-    adView.adSize = getSize(args?.get("adSize") as HashMap<*, *>)
+    adView.adSize = getSize(context, args?.get("adSize") as HashMap<*, *>)
     adView.adUnitId = args?.get("adUnitId") as String?
 
     val adRequest = AdRequest.Builder().build()
     adView.loadAd(adRequest)
   }
 
-  private fun getSize(size: HashMap<*, *>) : AdSize {
+  private fun getSize(context: Context, size: HashMap<*, *>) : AdSize {
     val width = size["width"] as Int
     val height = size["height"] as Int
     val name = size["name"] as String
@@ -39,6 +38,7 @@ class AdmobBanner(context: Context, messenger: BinaryMessenger, id: Int, args: H
       "FULL_BANNER" -> AdSize.FULL_BANNER
       "LEADERBOARD" -> AdSize.LEADERBOARD
       "SMART_BANNER" -> AdSize.SMART_BANNER
+      "ADAPTIVE_BANNER" -> AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(context, width)
       else -> AdSize(width, height)
     }
   }

--- a/android/src/main/kotlin/com/shatsy/admobflutter/AdmobFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/shatsy/admobflutter/AdmobFlutterPlugin.kt
@@ -2,12 +2,13 @@ package com.shatsy.admobflutter
 
 import android.content.Context
 import com.google.android.gms.ads.AdListener
+import com.google.android.gms.ads.AdSize
+import com.google.android.gms.ads.MobileAds
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 import io.flutter.plugin.common.PluginRegistry.Registrar
-import com.google.android.gms.ads.MobileAds
 
 fun createAdListener(channel: MethodChannel) : AdListener {
   return object: AdListener() {
@@ -42,8 +43,29 @@ class AdmobFlutterPlugin(private val context: Context): MethodCallHandler {
 
   override fun onMethodCall(call: MethodCall, result: Result) {
     when(call.method) {
-      "getPlatformVersion" -> result.success("Android ${android.os.Build.VERSION.RELEASE}")
       "initialize" -> MobileAds.initialize(context)
+      "banner_size" -> {
+        val args = call.arguments as HashMap<*, *>
+        val name = args["name"] as String
+        val width = args["width"] as Int
+        when(name) {
+          "SMART_BANNER" -> {
+            val metrics = context.resources.displayMetrics
+            result.success(hashMapOf(
+                    "width" to AdSize.SMART_BANNER.getWidthInPixels(context) / metrics.density,
+                    "height" to AdSize.SMART_BANNER.getHeightInPixels(context) / metrics.density
+            ))
+          }
+          "ADAPTIVE_BANNER" -> {
+            val adSize = AdSize.getCurrentOrientationAnchoredAdaptiveBannerAdSize(context, width)
+            result.success(hashMapOf(
+              "width" to adSize.width,
+              "height" to adSize.height
+            ))
+          }
+          else -> result.error("banner_size",  "not implemented name", name)
+        }
+      }
       else -> result.notImplemented()
     }
   }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,81 +1,81 @@
 PODS:
-  - admob_flutter (0.3.4):
+  - admob_flutter (1.0.0-beta):
     - Firebase/AdMob
     - Firebase/Analytics
-    - FirebaseAnalytics (~> 6.1.3)
     - Flutter
-    - Google-Mobile-Ads-SDK (~> 7.50)
-  - Firebase/AdMob (6.10.0):
+    - Google-Mobile-Ads-SDK (~> 7.57)
+  - Firebase/AdMob (6.20.0):
     - Firebase/CoreOnly
     - Google-Mobile-Ads-SDK (~> 7.50)
-  - Firebase/Analytics (6.10.0):
+  - Firebase/Analytics (6.20.0):
     - Firebase/Core
-  - Firebase/Core (6.10.0):
+  - Firebase/Core (6.20.0):
     - Firebase/CoreOnly
-    - FirebaseAnalytics (= 6.1.3)
-  - Firebase/CoreOnly (6.10.0):
-    - FirebaseCore (= 6.3.1)
-  - FirebaseAnalytics (6.1.3):
-    - FirebaseCore (~> 6.3)
-    - FirebaseInstanceID (~> 4.2)
-    - GoogleAppMeasurement (= 6.1.3)
+    - FirebaseAnalytics (= 6.3.1)
+  - Firebase/CoreOnly (6.20.0):
+    - FirebaseCore (= 6.6.4)
+  - FirebaseAnalytics (6.3.1):
+    - FirebaseCore (~> 6.6)
+    - FirebaseInstallations (~> 1.1)
+    - GoogleAppMeasurement (= 6.3.1)
     - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
     - GoogleUtilities/MethodSwizzler (~> 6.0)
     - GoogleUtilities/Network (~> 6.0)
     - "GoogleUtilities/NSData+zlib (~> 6.0)"
+    - nanopb (= 0.3.9011)
+  - FirebaseCore (6.6.4):
+    - FirebaseCoreDiagnostics (~> 1.2)
+    - FirebaseCoreDiagnosticsInterop (~> 1.2)
+    - GoogleUtilities/Environment (~> 6.5)
+    - GoogleUtilities/Logger (~> 6.5)
+  - FirebaseCoreDiagnostics (1.2.2):
+    - FirebaseCoreDiagnosticsInterop (~> 1.2)
+    - GoogleDataTransportCCTSupport (~> 2.0)
+    - GoogleUtilities/Environment (~> 6.5)
+    - GoogleUtilities/Logger (~> 6.5)
     - nanopb (~> 0.3.901)
-  - FirebaseCore (6.3.1):
-    - FirebaseCoreDiagnostics (~> 1.0)
-    - FirebaseCoreDiagnosticsInterop (~> 1.0)
-    - GoogleUtilities/Environment (~> 6.2)
-    - GoogleUtilities/Logger (~> 6.2)
-  - FirebaseCoreDiagnostics (1.1.1):
-    - FirebaseCoreDiagnosticsInterop (~> 1.0)
-    - GoogleDataTransportCCTSupport (~> 1.0)
-    - GoogleUtilities/Environment (~> 6.2)
-    - GoogleUtilities/Logger (~> 6.2)
-    - nanopb (~> 0.3.901)
-  - FirebaseCoreDiagnosticsInterop (1.0.0)
-  - FirebaseInstanceID (4.2.5):
-    - FirebaseCore (~> 6.0)
-    - GoogleUtilities/Environment (~> 6.0)
-    - GoogleUtilities/UserDefaults (~> 6.0)
+  - FirebaseCoreDiagnosticsInterop (1.2.0)
+  - FirebaseInstallations (1.1.0):
+    - FirebaseCore (~> 6.6)
+    - GoogleUtilities/UserDefaults (~> 6.5)
+    - PromisesObjC (~> 1.2)
   - Flutter (1.0.0)
-  - Google-Mobile-Ads-SDK (7.50.0):
+  - Google-Mobile-Ads-SDK (7.57.0):
     - GoogleAppMeasurement (~> 6.0)
-  - GoogleAppMeasurement (6.1.3):
+  - GoogleAppMeasurement (6.3.1):
     - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
     - GoogleUtilities/MethodSwizzler (~> 6.0)
     - GoogleUtilities/Network (~> 6.0)
     - "GoogleUtilities/NSData+zlib (~> 6.0)"
+    - nanopb (= 0.3.9011)
+  - GoogleDataTransport (5.0.0)
+  - GoogleDataTransportCCTSupport (2.0.0):
+    - GoogleDataTransport (~> 5.0)
     - nanopb (~> 0.3.901)
-  - GoogleDataTransport (3.0.1)
-  - GoogleDataTransportCCTSupport (1.2.1):
-    - GoogleDataTransport (~> 3.0)
-    - nanopb (~> 0.3.901)
-  - GoogleUtilities/AppDelegateSwizzler (6.3.1):
+  - GoogleUtilities/AppDelegateSwizzler (6.5.2):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
     - GoogleUtilities/Network
-  - GoogleUtilities/Environment (6.3.1)
-  - GoogleUtilities/Logger (6.3.1):
+  - GoogleUtilities/Environment (6.5.2)
+  - GoogleUtilities/Logger (6.5.2):
     - GoogleUtilities/Environment
-  - GoogleUtilities/MethodSwizzler (6.3.1):
+  - GoogleUtilities/MethodSwizzler (6.5.2):
     - GoogleUtilities/Logger
-  - GoogleUtilities/Network (6.3.1):
+  - GoogleUtilities/Network (6.5.2):
     - GoogleUtilities/Logger
     - "GoogleUtilities/NSData+zlib"
     - GoogleUtilities/Reachability
-  - "GoogleUtilities/NSData+zlib (6.3.1)"
-  - GoogleUtilities/Reachability (6.3.1):
+  - "GoogleUtilities/NSData+zlib (6.5.2)"
+  - GoogleUtilities/Reachability (6.5.2):
     - GoogleUtilities/Logger
-  - GoogleUtilities/UserDefaults (6.3.1):
+  - GoogleUtilities/UserDefaults (6.5.2):
     - GoogleUtilities/Logger
-  - nanopb (0.3.901):
-    - nanopb/decode (= 0.3.901)
-    - nanopb/encode (= 0.3.901)
-  - nanopb/decode (0.3.901)
-  - nanopb/encode (0.3.901)
+  - nanopb (0.3.9011):
+    - nanopb/decode (= 0.3.9011)
+    - nanopb/encode (= 0.3.9011)
+  - nanopb/decode (0.3.9011)
+  - nanopb/encode (0.3.9011)
+  - PromisesObjC (1.2.8)
 
 DEPENDENCIES:
   - admob_flutter (from `.symlinks/plugins/admob_flutter/ios`)
@@ -88,13 +88,14 @@ SPEC REPOS:
     - FirebaseCore
     - FirebaseCoreDiagnostics
     - FirebaseCoreDiagnosticsInterop
-    - FirebaseInstanceID
+    - FirebaseInstallations
     - Google-Mobile-Ads-SDK
     - GoogleAppMeasurement
     - GoogleDataTransport
     - GoogleDataTransportCCTSupport
     - GoogleUtilities
     - nanopb
+    - PromisesObjC
 
 EXTERNAL SOURCES:
   admob_flutter:
@@ -103,21 +104,22 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  admob_flutter: 8033bcca85371a0554aa99d525a83a4770e679f0
-  Firebase: 5e6b7b12bf9adb90986688edc06b156c37e109cd
-  FirebaseAnalytics: 0e3ecff2c5d86070f7d4325e21f1edabfbd558dc
-  FirebaseCore: 064c2dd92a8ca5974bbdcb080df9921e46bd34cd
-  FirebaseCoreDiagnostics: af29e43048607588c050889d19204f4d7b758c9f
-  FirebaseCoreDiagnosticsInterop: 6829da2b8d1fc795ff1bd99df751d3788035d2cb
-  FirebaseInstanceID: 550df9be1f99f751d8fcde3ac342a1e21a0e6c42
+  admob_flutter: ee0dd62b51c257bb352ee8a208fc62a83a37a113
+  Firebase: fe7f74012742ab403451dd283e6909b8f1fb348a
+  FirebaseAnalytics: 572e467f3d977825266e8ccd52674aa3e6f47eac
+  FirebaseCore: ed0a24c758a57c2b88c5efa8e6a8195e868af589
+  FirebaseCoreDiagnostics: e9b4cd8ba60dee0f2d13347332e4b7898cca5b61
+  FirebaseCoreDiagnosticsInterop: 296e2c5f5314500a850ad0b83e9e7c10b011a850
+  FirebaseInstallations: 575cd32f2aec0feeb0e44f5d0110a09e5e60b47b
   Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
-  Google-Mobile-Ads-SDK: d48dbaf5bae1ab7a94a9786f493c26c454bc6f16
-  GoogleAppMeasurement: 434cc7be25e71dc04b8d0e3079125127b330e84a
-  GoogleDataTransport: 166f9b9f82cbf60a204e8fe2daa9db3e3ec1fb15
-  GoogleDataTransportCCTSupport: f6ab1962e9dc05ab1fb938b795e5b310209edeec
-  GoogleUtilities: f895fde57977df4e0233edda0dbeac490e3703b6
-  nanopb: 2901f78ea1b7b4015c860c2fdd1ea2fee1a18d48
+  Google-Mobile-Ads-SDK: ec897018b9ab9b447e7aa4876e7f75aba13ba2de
+  GoogleAppMeasurement: c29d405ff76e18551b5d158eaba6753fda8c7542
+  GoogleDataTransport: a857c6a002d201b524dd4bc2ed7e7355ed07e785
+  GoogleDataTransportCCTSupport: 32f75fbe904c82772fcbb6b6bd4525bfb6f2a862
+  GoogleUtilities: ad0f3b691c67909d03a3327cc205222ab8f42e0e
+  nanopb: 18003b5e52dab79db540fe93fe9579f399bd1ccd
+  PromisesObjC: c119f3cd559f50b7ae681fa59dc1acd19173b7e6
 
 PODFILE CHECKSUM: 1b66dae606f75376c5f2135a8290850eeb09ae83
 
-COCOAPODS: 1.8.3
+COCOAPODS: 1.8.4

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -45,8 +45,7 @@ class _MyAppState extends State<MyApp> {
     rewardAd.load();
   }
 
-  void handleEvent(
-      AdmobAdEvent event, Map<String, dynamic> args, String adType) {
+  void handleEvent(AdmobAdEvent event, Map<String, dynamic> args, String adType) {
     switch (event) {
       case AdmobAdEvent.loaded:
         showSnackBar('New Admob $adType Ad loaded!');
@@ -109,62 +108,61 @@ class _MyAppState extends State<MyApp> {
         bottomNavigationBar: Builder(
           builder: (BuildContext context) {
             return Container(
-              height: 50,
               color: Colors.blueGrey,
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: <Widget>[
-                  Expanded(
-                    child: FlatButton(
-                      child: Text(
-                        'Show Interstitial',
-                        style: TextStyle(color: Colors.white),
-                      ),
-                      onPressed: () async {
-                        if (await interstitialAd.isLoaded) {
-                          interstitialAd.show();
-                        } else {
-                          showSnackBar("Interstitial ad is still loading...");
-                        }
-                      },
-                      shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.zero),
-                    ),
-                  ),
-                  Expanded(
-                    child: FlatButton(
-                      child: Text(
-                        'Show Reward',
-                        style: TextStyle(color: Colors.white),
-                      ),
-                      onPressed: () async {
-                        if (await rewardAd.isLoaded) {
-                          rewardAd.show();
-                        } else {
-                          showSnackBar("Reward ad is still loading...");
-                        }
-                      },
-                    ),
-                  ),
-                  Expanded(
-                    child: PopupMenuButton(
-                      initialValue: bannerSize,
-                      child: Center(
-                        child: Text(
-                          'Banner size',
-                          style: TextStyle(
-                              fontWeight: FontWeight.w500, color: Colors.white),
+              child: SafeArea(
+                child: SizedBox(
+                  height: 50,
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: <Widget>[
+                      Expanded(
+                        child: FlatButton(
+                          child: Text(
+                            'Show Interstitial',
+                            style: TextStyle(color: Colors.white),
+                          ),
+                          onPressed: () async {
+                            if (await interstitialAd.isLoaded) {
+                              interstitialAd.show();
+                            } else {
+                              showSnackBar("Interstitial ad is still loading...");
+                            }
+                          },
+                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.zero),
                         ),
                       ),
-                      offset: Offset(0, 20),
-                      onSelected: (AdmobBannerSize newSize) {
-                        setState(() {
-                          bannerSize = newSize;
-                        });
-                      },
-                      itemBuilder: (BuildContext context) =>
-                          <PopupMenuEntry<AdmobBannerSize>>[
+                      Expanded(
+                        child: FlatButton(
+                          child: Text(
+                            'Show Reward',
+                            style: TextStyle(color: Colors.white),
+                          ),
+                          onPressed: () async {
+                            if (await rewardAd.isLoaded) {
+                              rewardAd.show();
+                            } else {
+                              showSnackBar("Reward ad is still loading...");
+                            }
+                          },
+                        ),
+                      ),
+                      Expanded(
+                        child: PopupMenuButton(
+                          initialValue: bannerSize,
+                          child: Center(
+                            child: Text(
+                              'Banner size',
+                              style: TextStyle(fontWeight: FontWeight.w500, color: Colors.white),
+                            ),
+                          ),
+                          offset: Offset(0, 20),
+                          onSelected: (AdmobBannerSize newSize) {
+                            setState(() {
+                              bannerSize = newSize;
+                            });
+                          },
+                          itemBuilder: (BuildContext context) => <PopupMenuEntry<AdmobBannerSize>>[
                             PopupMenuItem(
                               value: AdmobBannerSize.BANNER,
                               child: Text('BANNER'),
@@ -186,13 +184,22 @@ class _MyAppState extends State<MyApp> {
                               child: Text('LEADERBOARD'),
                             ),
                             PopupMenuItem(
-                              value: AdmobBannerSize.SMART_BANNER,
+                              value: AdmobBannerSize.SMART_BANNER(context),
                               child: Text('SMART_BANNER'),
                             ),
+                            PopupMenuItem(
+                              value: AdmobBannerSize.ADAPTIVE_BANNER(
+                                width:
+                                    MediaQuery.of(context).size.width.toInt() - 40, // considering EdgeInsets.all(20.0)
+                              ),
+                              child: Text('ADAPTIVE_BANNER'),
+                            ),
                           ],
-                    ),
+                        ),
+                      ),
+                    ],
                   ),
-                ],
+                ),
               ),
             );
           },
@@ -209,8 +216,7 @@ class _MyAppState extends State<MyApp> {
                     child: AdmobBanner(
                       adUnitId: getBannerAdUnitId(),
                       adSize: bannerSize,
-                      listener:
-                          (AdmobAdEvent event, Map<String, dynamic> args) {
+                      listener: (AdmobAdEvent event, Map<String, dynamic> args) {
                         handleEvent(event, args, 'Banner');
                       },
                     ),
@@ -299,4 +305,3 @@ String getRewardBasedVideoAdUnitId() {
   }
   return null;
 }
-

--- a/ios/Classes/SwiftAdmobFlutterPlugin.swift
+++ b/ios/Classes/SwiftAdmobFlutterPlugin.swift
@@ -42,7 +42,30 @@ public class SwiftAdmobFlutterPlugin: NSObject, FlutterPlugin {
         GADMobileAds.sharedInstance().start { (status: GADInitializationStatus) in
             print("iOS Admob status: \(status.adapterStatusesByClassName)")
         }
-        break
+    case "banner_size":
+        guard let args = call.arguments as? [String: Any],
+            let name = args["name"] as? String,
+            let width = args["width"] as? CGFloat else {
+                result(FlutterError(code: "banner_size", message: "invalid arguments", details: call.arguments))
+                return
+        }
+        switch name {
+        case "SMART_BANNER":
+            // TODO: Do we need Landscape too?
+            let height: CGFloat = UIApplication.shared.keyWindow?.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClass.compact ? 50 : 90;
+            result([
+                "width": width,
+                "height": height,
+            ])
+        case "ADAPTIVE_BANNER":
+            let adSize = GADCurrentOrientationAnchoredAdaptiveBannerAdSizeWithWidth(width)
+            result([
+                "width": adSize.size.width,
+                "height": adSize.size.height,
+            ])
+        default:
+            result(FlutterError(code: "banner_size", message: "not implemented name", details: name))
+        }
     default:
         result(FlutterMethodNotImplemented)
     }

--- a/ios/admob_flutter.podspec
+++ b/ios/admob_flutter.podspec
@@ -18,11 +18,9 @@ Admob plugin that shows banner ads using native platform views.
   s.dependency 'Flutter'
   
   # https://firebase.google.com/docs/ios/setup
-  # https://github.com/CocoaPods/Specs/blob/master/Specs/0/3/5/Firebase/6.10.0/Firebase.podspec.json
   s.dependency 'Firebase/Analytics'
-  s.dependency 'FirebaseAnalytics', '~> 6.1.3'
   s.dependency 'Firebase/AdMob'
-  s.dependency 'Google-Mobile-Ads-SDK', '~> 7.50'
+  s.dependency 'Google-Mobile-Ads-SDK', '~> 7.57'
 
   s.ios.deployment_target = '8.0'
   s.static_framework = true

--- a/lib/src/admob.dart
+++ b/lib/src/admob.dart
@@ -11,7 +11,7 @@ class Admob {
 
   static Future<Size> bannerSize(AdmobBannerSize admobBannerSize) async {
     final rawResult = await _channel.invokeMethod('banner_size', admobBannerSize.toMap);
-    final resultMap = Map<String, dynamic>.from(rawResult);
-    return Size(resultMap["width"], resultMap["height"]);
+    final resultMap = Map<String, num>.from(rawResult);
+    return Size(resultMap["width"].ceilToDouble(), resultMap["height"].ceilToDouble());
   }
 }

--- a/lib/src/admob.dart
+++ b/lib/src/admob.dart
@@ -1,8 +1,17 @@
+import 'dart:ui';
 import 'package:flutter/services.dart';
+import 'package:admob_flutter/admob_flutter.dart';
 
 class Admob {
+  static const _channel = MethodChannel('admob_flutter');
+
   Admob.initialize(String appId) {
-    MethodChannel _channel = const MethodChannel('admob_flutter');
     _channel.invokeMethod('initialize', appId);
+  }
+
+  static Future<Size> bannerSize(AdmobBannerSize admobBannerSize) async {
+    final rawResult = await _channel.invokeMethod('banner_size', admobBannerSize.toMap);
+    final resultMap = Map<String, dynamic>.from(rawResult);
+    return Size(resultMap["width"], resultMap["height"]);
   }
 }

--- a/lib/src/admob_banner_size.dart
+++ b/lib/src/admob_banner_size.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:meta/meta.dart';
 
 class AdmobBannerSize {
@@ -14,14 +15,18 @@ class AdmobBannerSize {
       AdmobBannerSize(width: 468, height: 60, name: 'FULL_BANNER');
   static const AdmobBannerSize LEADERBOARD =
       AdmobBannerSize(width: 728, height: 90, name: 'LEADERBOARD');
-  static const AdmobBannerSize SMART_BANNER =
-      AdmobBannerSize(width: -1, height: -2, name: 'SMART_BANNER');
+  AdmobBannerSize.SMART_BANNER(BuildContext context):
+        this.width = MediaQuery.of(context).size.width.toInt(), this.height = -2, this.name = 'SMART_BANNER';
+  AdmobBannerSize.ADAPTIVE_BANNER({@required int width}):
+      this.width = width, this.height = -2, this.name = 'ADAPTIVE_BANNER';
 
   const AdmobBannerSize({
     @required this.width,
     @required this.height,
     this.name,
   });
+
+  bool get hasFixedSize => width > 0 && height > 0;
 
   Map<String, dynamic> get toMap => <String, dynamic>{
         'width': width,

--- a/lib/src/admob_banner_size.dart
+++ b/lib/src/admob_banner_size.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 
 class AdmobBannerSize {


### PR DESCRIPTION
Adaptive Banner is the latest banner style.  https://developers.google.com/admob/android/banner/adaptive

AdMob banner view displayed by platform view cannot use variable banner size because there are differences of layout system with native so platform view cannot fit to native view's `intrinsicContentSize` (iOS) or `WRAP_CONTENT` (Android). To fit the banner size, we need to know that of displaying size first.
There are no way to know the size of `SMART_BANNER` but adaptive banner can do it.
Adaptive banner is good to place a banner fitting with design ( and eCPM😁).
