### PR TITLE
Upgrade Google Mobile Ads SDK to version 7.64 to support iOS 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ and add
 <true/>
 ```
 
+Starting from Beta 6, you also need to display the App Tracking Transparency authorization request for accessing the IDFA,
+so you have to update your `Info.plist` to add the `NSUserTrackingUsageDescription` key with a custom message describing your usage.
+Below is an example description text:
+```xml
+<key>NSUserTrackingUsageDescription</key>
+<string>This identifier will be used to deliver personalized ads to you.</string>
+```
+
+See [Prepare for iOS 14+](https://developers.google.com/admob/ios/ios14) for more information.
+
 ### Initialize the plugin
 
 First thing to do before attempting to show any ads is to initialize the plugin. You can do this in the earliest starting point of your app, your `main` function:

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ void main() {
 
 If you're using iOS, you may also need to request the tracking authorization in order to display personalized ads:
 
-```
+```dart
 // Run this before displaying any ad.
 await Admob.requestTrackingAuthorization();
 ```

--- a/README.md
+++ b/README.md
@@ -82,11 +82,18 @@ import 'package:admob_flutter/admob_flutter.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
-  // Initialize without device test ids
+  // Initialize without device test ids.
   Admob.initialize();
   // Or add a list of test ids.
   // Admob.initialize(testDeviceIds: ['YOUR DEVICE ID']);
 }
+```
+
+If you're using iOS, you may also need to request the tracking authorization in order to display personalized ads:
+
+```
+// Run this before displaying any ad.
+await Admob.requestTrackingAuthorization();
 ```
 
 ### Supported Platforms

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Below is an example description text:
 ```
 
 See [Prepare for iOS 14+](https://developers.google.com/admob/ios/ios14) for more information.
+You also need to update your `ios/Podfile` by adding `platform :ios, '9.0'` at the very top of your file.
 
 ### Initialize the plugin
 

--- a/android/src/main/kotlin/com/shatsy/admobflutter/AdmobFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/shatsy/admobflutter/AdmobFlutterPlugin.kt
@@ -52,7 +52,6 @@ class AdmobFlutterPlugin(private val context: Context): MethodCallHandler {
             val configuration = RequestConfiguration.Builder().setTestDeviceIds(this).build()
             MobileAds.setRequestConfiguration(configuration)
         }
-		result.success(true)
       }
       "banner_size" -> {
         val args = call.arguments as HashMap<*, *>

--- a/android/src/main/kotlin/com/shatsy/admobflutter/AdmobFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/shatsy/admobflutter/AdmobFlutterPlugin.kt
@@ -52,6 +52,7 @@ class AdmobFlutterPlugin(private val context: Context): MethodCallHandler {
             val configuration = RequestConfiguration.Builder().setTestDeviceIds(this).build()
             MobileAds.setRequestConfiguration(configuration)
         }
+		result.success(true)
       }
       "banner_size" -> {
         val args = call.arguments as HashMap<*, *>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -32,6 +32,8 @@ class _MyMaterialAppState extends State<MyMaterialApp> {
   void initState() {
     super.initState();
 
+	// You should execute `Admob.requestTrackingAuthorization()` here before showing any ad.
+
     bannerSize = AdmobBannerSize.BANNER;
 
     interstitialAd = AdmobInterstitial(

--- a/ios/Classes/SwiftAdmobFlutterPlugin.swift
+++ b/ios/Classes/SwiftAdmobFlutterPlugin.swift
@@ -18,6 +18,8 @@
 
 import UIKit
 import GoogleMobileAds
+import AppTrackingTransparency
+import AdSupport
 
 public class SwiftAdmobFlutterPlugin: NSObject, FlutterPlugin {
     
@@ -44,6 +46,15 @@ public class SwiftAdmobFlutterPlugin: NSObject, FlutterPlugin {
         if let args = call.arguments as? [String] {
             GADMobileAds.sharedInstance().requestConfiguration.testDeviceIdentifiers = args
         }
+		if #available(iOS 14, *) {
+			ATTrackingManager.requestTrackingAuthorization(completionHandler: { status in
+				print("Tracking authorization completed. \(status)")
+				result(status == ATTrackingManager.AuthorizationStatus.authorized)
+			})
+		}
+		else {
+			result(true)
+		}
     case "banner_size":
         guard let args = call.arguments as? [String: Any],
             let name = args["name"] as? String,

--- a/ios/Classes/SwiftAdmobFlutterPlugin.swift
+++ b/ios/Classes/SwiftAdmobFlutterPlugin.swift
@@ -46,6 +46,7 @@ public class SwiftAdmobFlutterPlugin: NSObject, FlutterPlugin {
         if let args = call.arguments as? [String] {
             GADMobileAds.sharedInstance().requestConfiguration.testDeviceIdentifiers = args
         }
+	case "request_tracking_authorization":
 		if #available(iOS 14, *) {
 			ATTrackingManager.requestTrackingAuthorization(completionHandler: { status in
 				print("Tracking authorization completed. \(status)")

--- a/ios/admob_flutter.podspec
+++ b/ios/admob_flutter.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'admob_flutter'
-  s.version          = '1.0.0-beta.3'
+  s.version          = '1.0.0-beta.5'
   s.swift_version    = '5.0'
   s.summary          = 'Admob plugin that shows banner ads using native platform views.'
   s.description      = <<-DESC
@@ -18,9 +18,9 @@ Admob plugin that shows banner ads using native platform views.
   s.dependency 'Flutter'
   
   # https://firebase.google.com/docs/ios/setup
-  s.dependency 'Firebase/Analytics', '~> 6.5'
+  s.dependency 'Firebase/Analytics', '~> 6.7.2'
   s.dependency 'Firebase/AdMob'
-  s.dependency 'Google-Mobile-Ads-SDK', '~> 7.59'
+  s.dependency 'Google-Mobile-Ads-SDK', '~> 7.64'
 
   s.ios.deployment_target = '8.0'
   s.static_framework = true

--- a/lib/src/admob.dart
+++ b/lib/src/admob.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'dart:ui';
 import 'package:flutter/services.dart';
 import 'package:admob_flutter/admob_flutter.dart';
@@ -5,7 +6,16 @@ import 'package:admob_flutter/admob_flutter.dart';
 class Admob {
   static const _channel = MethodChannel('admob_flutter');
 
-  static Future<bool> initialize({List<String> testDeviceIds}) async => _channel.invokeMethod('initialize', testDeviceIds);
+  Admob.initialize({List<String> testDeviceIds}) {
+    _channel.invokeMethod('initialize', testDeviceIds);
+  }
+  
+  static Future<bool> requestTrackingAuthorization() {
+	if (!Platform.isIOS) {
+		return Future.value(true);
+	}
+	return _channel.invokeMethod('request_tracking_authorization');
+  }
 
   static Future<Size> bannerSize(AdmobBannerSize admobBannerSize) async {
     final rawResult = await _channel.invokeMethod('banner_size', admobBannerSize.toMap);

--- a/lib/src/admob.dart
+++ b/lib/src/admob.dart
@@ -5,9 +5,7 @@ import 'package:admob_flutter/admob_flutter.dart';
 class Admob {
   static const _channel = MethodChannel('admob_flutter');
 
-  Admob.initialize({List<String> testDeviceIds}) {
-    _channel.invokeMethod('initialize', testDeviceIds);
-  }
+  static Future<bool> initialize({List<String> testDeviceIds}) async => _channel.invokeMethod('initialize', testDeviceIds);
 
   static Future<Size> bannerSize(AdmobBannerSize admobBannerSize) async {
     final rawResult = await _channel.invokeMethod('banner_size', admobBannerSize.toMap);


### PR DESCRIPTION
This pull request :
* Upgrades Google Mobile Ads SDK to version 7.64 to support iOS 14.
* Adds `Admob.requestTrackingAuthorization()` to request the new Tracking authorization on iOS.
* Adds required install steps to the README.
* Should fix #208 and #189.

Please note that [you need Xcode 12 to compile this version](https://stackoverflow.com/questions/63516131/no-such-module-apptrackingtransparency-error).