### PR TITLE
Add test ad unit ids

### DIFF
--- a/lib/src/admob_banner.dart
+++ b/lib/src/admob_banner.dart
@@ -24,9 +24,15 @@ class AdmobBanner extends StatefulWidget {
     this.nonPersonalizedAds = false,
   }) : super(key: key);
 
-  static final String testAdUnitId = Platform.isAndroid
-	? 'ca-app-pub-3940256099942544/6300978111'
-	: 'ca-app-pub-3940256099942544/2934735716';
+  static String get testAdUnitId {
+    if (Platform.isAndroid) {
+      return 'ca-app-pub-3940256099942544/6300978111';
+    } else if (Platform.isIOS) {
+      return 'ca-app-pub-3940256099942544/2934735716';
+    } else {
+      throw UnsupportedError('Unsupported platform');
+    }
+  }
 
   @override
   _AdmobBannerState createState() => _AdmobBannerState();

--- a/lib/src/admob_banner.dart
+++ b/lib/src/admob_banner.dart
@@ -1,3 +1,5 @@
+import 'dart:io' show Platform;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -21,6 +23,10 @@ class AdmobBanner extends StatefulWidget {
     this.onBannerCreated,
     this.nonPersonalizedAds = false,
   }) : super(key: key);
+
+  static final String testAdUnitId = Platform.isAndroid
+	? 'ca-app-pub-3940256099942544/6300978111'
+	: 'ca-app-pub-3940256099942544/2934735716';
 
   @override
   _AdmobBannerState createState() => _AdmobBannerState();

--- a/lib/src/admob_interstitial.dart
+++ b/lib/src/admob_interstitial.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io' show Platform;
 
 import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
@@ -25,6 +26,10 @@ class AdmobInterstitial extends AdmobEventHandler {
       _adChannel.setMethodCallHandler(handleEvent);
     }
   }
+
+  static final String testAdUnitId = Platform.isAndroid
+	? 'ca-app-pub-3940256099942544/1033173712'
+	: 'ca-app-pub-3940256099942544/4411468910';
 
   Future<bool> get isLoaded async {
     final result = await _channel.invokeMethod('isLoaded', _channelMethodsArguments);

--- a/lib/src/admob_interstitial.dart
+++ b/lib/src/admob_interstitial.dart
@@ -27,9 +27,15 @@ class AdmobInterstitial extends AdmobEventHandler {
     }
   }
 
-  static final String testAdUnitId = Platform.isAndroid
-	? 'ca-app-pub-3940256099942544/1033173712'
-	: 'ca-app-pub-3940256099942544/4411468910';
+  static String get testAdUnitId {
+    if (Platform.isAndroid) {
+      return 'ca-app-pub-3940256099942544/1033173712';
+    } else if (Platform.isIOS) {
+      return 'ca-app-pub-3940256099942544/4411468910';
+    } else {
+      throw UnsupportedError('Unsupported platform');
+    }
+  }
 
   Future<bool> get isLoaded async {
     final result = await _channel.invokeMethod('isLoaded', _channelMethodsArguments);

--- a/lib/src/admob_reward.dart
+++ b/lib/src/admob_reward.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io' show Platform;
 
 import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
@@ -25,6 +26,10 @@ class AdmobReward extends AdmobEventHandler {
       _adChannel.setMethodCallHandler(handleEvent);
     }
   }
+
+  static final String testAdUnitId = Platform.isAndroid
+	? 'ca-app-pub-3940256099942544/5224354917'
+	: 'ca-app-pub-3940256099942544/1712485313';
 
   Future<bool> get isLoaded async {
     final result = await _channel.invokeMethod('isLoaded', _channelMethodsArguments);

--- a/lib/src/admob_reward.dart
+++ b/lib/src/admob_reward.dart
@@ -27,9 +27,15 @@ class AdmobReward extends AdmobEventHandler {
     }
   }
 
-  static final String testAdUnitId = Platform.isAndroid
-	? 'ca-app-pub-3940256099942544/5224354917'
-	: 'ca-app-pub-3940256099942544/1712485313';
+  static String get testAdUnitId {
+    if (Platform.isAndroid) {
+      return 'ca-app-pub-3940256099942544/5224354917';
+    } else if (Platform.isIOS) {
+      return 'ca-app-pub-3940256099942544/1712485313';
+    } else {
+      throw UnsupportedError('Unsupported platform');
+    }
+  }
 
   Future<bool> get isLoaded async {
     final result = await _channel.invokeMethod('isLoaded', _channelMethodsArguments);


### PR DESCRIPTION
Every time I initially figure out ad placements, I have to look up various test ad unit ids. This PR adds them as static members to the different ad classes for easy access. I took the test ad unit ids from the [Android](https://developers.google.com/admob/android/test-ads) and [iOS](https://developers.google.com/admob/ios/test-ads) docs for "Enabling test ads".

IMHO its a useful addition that eases the setup experience.