### PR TITLE
Restored testAdUnitId

### DIFF
--- a/lib/src/admob_banner.dart
+++ b/lib/src/admob_banner.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -21,6 +23,16 @@ class AdmobBanner extends StatefulWidget {
     this.onBannerCreated,
     this.nonPersonalizedAds = false,
   }) : super(key: key);
+
+  static String get testAdUnitId {
+    if (Platform.isAndroid) {
+      return 'ca-app-pub-3940256099942544/6300978111';
+    } else if (Platform.isIOS) {
+      return 'ca-app-pub-3940256099942544/2934735716';
+    } else {
+      throw UnsupportedError('Unsupported platform');
+    }
+  }
 
   @override
   _AdmobBannerState createState() => _AdmobBannerState();

--- a/lib/src/admob_interstitial.dart
+++ b/lib/src/admob_interstitial.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/services.dart';
 import 'admob_event_handler.dart';
@@ -22,6 +23,16 @@ class AdmobInterstitial extends AdmobEventHandler {
     if (listener != null) {
       _adChannel = MethodChannel('admob_flutter/interstitial_$id');
       _adChannel.setMethodCallHandler(handleEvent);
+    }
+  }
+
+  static String get testAdUnitId {
+    if (Platform.isAndroid) {
+      return 'ca-app-pub-3940256099942544/1033173712';
+    } else if (Platform.isIOS) {
+      return 'ca-app-pub-3940256099942544/4411468910';
+    } else {
+      throw UnsupportedError('Unsupported platform');
     }
   }
 

--- a/lib/src/admob_reward.dart
+++ b/lib/src/admob_reward.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/services.dart';
 import 'admob_event_handler.dart';
@@ -22,6 +23,16 @@ class AdmobReward extends AdmobEventHandler {
     if (listener != null) {
       _adChannel = MethodChannel('admob_flutter/reward_$id');
       _adChannel.setMethodCallHandler(handleEvent);
+    }
+  }
+
+  static String get testAdUnitId {
+    if (Platform.isAndroid) {
+      return 'ca-app-pub-3940256099942544/5224354917';
+    } else if (Platform.isIOS) {
+      return 'ca-app-pub-3940256099942544/1712485313';
+    } else {
+      throw UnsupportedError('Unsupported platform');
     }
   }
 


### PR DESCRIPTION
Restored testAdUnitId as initially done in #227 and required in #273.

Missing from `2.0.0-nullsafety.0`.

Closes #273 