### PR TITLE
updated obsolete firebase ads version in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,13 +25,13 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 23
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     lintOptions {
@@ -41,5 +41,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    api 'com.google.firebase:firebase-ads:19.1.0'
+    api 'com.google.firebase:firebase-ads:22.1.0'
 }


### PR DESCRIPTION
## Changes 
- upgraded firebase ads version to 22.1.0 May 2023 Release
- upgraded compiled sdk version to 33 
- removed support from SDK 16 to 22